### PR TITLE
Fix handling case when application code raises an error on command 

### DIFF
--- a/lib/yabeda/anycable/middleware.rb
+++ b/lib/yabeda/anycable/middleware.rb
@@ -11,7 +11,7 @@ module Yabeda
         (response = yield)
       ensure
         elapsed = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started).round(4)
-        labels = { method: rpc_method_name.to_s, status: response.status.to_s }
+        labels = { method: rpc_method_name.to_s, status: response.respond_to?(:status) ? response.status.to_s : "ERROR" }
         labels[:command] = request.respond_to?(:command) ? request.command : ""
         ::Yabeda.anycable.rpc_call_count.increment(labels)
         ::Yabeda.anycable.rpc_call_runtime.measure(labels, elapsed)

--- a/lib/yabeda/anycable/middleware.rb
+++ b/lib/yabeda/anycable/middleware.rb
@@ -11,8 +11,9 @@ module Yabeda
         (response = yield)
       ensure
         elapsed = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started).round(4)
-        labels = { method: rpc_method_name.to_s, status: response.respond_to?(:status) ? response.status.to_s : "ERROR" }
-        labels[:command] = request.respond_to?(:command) ? request.command : ""
+        status  = response.respond_to?(:status) ? response.status.to_s : "ERROR"
+        command = request.respond_to?(:command) ? request.command : ""
+        labels  = { method: rpc_method_name.to_s, status: status, command: command }
         ::Yabeda.anycable.rpc_call_count.increment(labels)
         ::Yabeda.anycable.rpc_call_runtime.measure(labels, elapsed)
       end

--- a/spec/yabeda/anycable/middleware_spec.rb
+++ b/spec/yabeda/anycable/middleware_spec.rb
@@ -32,6 +32,16 @@ RSpec.describe Yabeda::AnyCable::Middleware do
         .with(be_between(0.005, 0.05))
         .with_tags(method: "connect", command: "", status: "SUCCESS")
     end
+
+    context "when request handling fails" do
+      let(:block) { proc { raise "Something went wrong by itself!" } }
+
+      it "doesn't swallow exception (let AnyCable Exception middleware handle it)" do
+        expect { call_middleware }.to raise_exception(RuntimeError).and \
+          increment_yabeda_counter(Yabeda.anycable.rpc_call_count)
+          .with_tags(method: "connect", command: "", status: "ERROR")
+      end
+    end
   end
 
   context "with command request" do
@@ -54,6 +64,16 @@ RSpec.describe Yabeda::AnyCable::Middleware do
         measure_yabeda_histogram(Yabeda.anycable.rpc_call_runtime)
         .with(be_between(0.005, 0.05))
         .with_tags(method: "command", command: "subscribe", status: "SUCCESS")
+    end
+
+    context "when command handling fails" do
+      let(:block) { proc { raise ArgumentError, "You did something completely wrong!" } }
+
+      it "doesn't swallow exception (let AnyCable Exception middleware handle it)" do
+        expect { call_middleware }.to raise_exception(ArgumentError).and \
+          increment_yabeda_counter(Yabeda.anycable.rpc_call_count)
+          .with_tags(method: "command", command: "subscribe", status: "ERROR")
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/yabeda-rb/yabeda-anycable/issues/3

Ensure that we correctly set status in metrics to `ERROR` and re-raise exception so `AnyCable::Middlewares::Exceptions` can handle it.

Thanks @zlenderja for pointing this out.